### PR TITLE
Fix deprecation warnings for node12 actions and set-output commands

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -71,7 +71,7 @@ runs:
     - name: Create a pull request to update ${{ inputs.dependency }}
       if: ${{ steps.get_current_commit.outputs.rev != steps.get_new_commit.outputs.rev }}
       id: create_pr
-      uses: peter-evans/create-pull-request@v3
+      uses: peter-evans/create-pull-request@v4
       with:
         commit-message: "chore(flake/${{ inputs.dependency }}): ${{ steps.get_current_commit.outputs.short-rev }} -> ${{ steps.get_new_commit.outputs.short-rev }}"
         branch: "${{ inputs.pull-request-branch-prefix }}${{ inputs.dependency }}"

--- a/action.yml
+++ b/action.yml
@@ -58,7 +58,7 @@ runs:
         input: ${{ inputs.dependency }}
 
     - name: Get commit details for ${{ inputs.dependency }} changes
-      uses: cpcloud/compare-commits-action@v5.0.10
+      uses: cpcloud/compare-commits-action@v5.0.25
       id: compare_commits
       if: ${{ steps.get_current_commit.outputs.rev != steps.get_new_commit.outputs.rev }}
       with:

--- a/action.yml
+++ b/action.yml
@@ -43,7 +43,7 @@ runs:
   steps:
     - name: Get current commit
       id: get_current_commit
-      uses: cpcloud/flake-dep-info-action@v1.1.0
+      uses: cpcloud/flake-dep-info-action@v2.0.8
       with:
         input: ${{ inputs.dependency }}
 
@@ -53,7 +53,7 @@ runs:
 
     - name: Get new commit
       id: get_new_commit
-      uses: cpcloud/flake-dep-info-action@v1.1.0
+      uses: cpcloud/flake-dep-info-action@v2.0.8
       with:
         input: ${{ inputs.dependency }}
 

--- a/action.yml
+++ b/action.yml
@@ -84,7 +84,7 @@ runs:
 
     - name: Set the PR to automerge
       if: ${{ steps.create_pr.outputs.pull-request-operation == 'created' && fromJSON(inputs.automerge) }}
-      uses: peter-evans/enable-pull-request-automerge@v1
+      uses: peter-evans/enable-pull-request-automerge@v2
       with:
         token: ${{ inputs.pull-request-token }}
         pull-request-number: ${{ steps.create_pr.outputs.pull-request-number }}


### PR DESCRIPTION
Using `cpcloud/flake-update-action@v1.0.2` (the latest release at the moment) results in multiple deprecation warnings in the workflow logs:

> Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: cpcloud/flake-dep-info-action, cpcloud/flake-dep-info-action
>
> The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

These warnings are caused by some dependencies in `action.yml` referring to old versions of actions (not just the mentioned `cpcloud/flake-dep-info-action`, but also some other ones that need updating to avoid the deprecated `set-output` usage). Update those actions to avoid the deprecation warnings.